### PR TITLE
Uploads status + autoblog rotation + faster home & admin UX

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -22,6 +22,7 @@ import gDriveCallback from '../backend/handlers/gdrive_callback.js';
 import gDriveFinalize from '../backend/handlers/gdrive_finalize.js';
 import gDriveStatus from '../backend/handlers/gdrive_status.js';
 import gDriveImage from '../backend/handlers/gdrive_image.js';
+import uploadsStatus from '../backend/handlers/uploads_status.js';
 import oneDriveConnect from '../backend/handlers/onedrive_connect.js';
 import oneDriveCallback from '../backend/handlers/onedrive_callback.js';
 import oneDriveFinalize from '../backend/handlers/onedrive_finalize.js';
@@ -115,6 +116,7 @@ export default async function handler(req, res) {
 
     if (root === 'uploads') {
       if (rest.join('/') === 'image') return uploads(req, res);
+      if (rest.join('/') === 'status') return uploadsStatus(req, res);
       if (rest.join('/') === 'gdrive/connect') return gDriveConnect(req, res);
       if (rest.join('/') === 'gdrive/callback') return gDriveCallback(req, res);
       if (rest.join('/') === 'gdrive/finalize') return gDriveFinalize(req, res);

--- a/backend/handlers/cron_daily_blog.js
+++ b/backend/handlers/cron_daily_blog.js
@@ -334,13 +334,73 @@ export default async function handler(req, res) {
       return res.status(200).json({ success: true, skipped: true, reason: 'already posted today', id: existing.rows[0].id });
     }
 
-    const newsItems = await fetchNewsItems('funding grants loans opportunities technology health agriculture education energy manufacturing SMEs');
+    // Rotate angle/topic so we don't publish near-identical posts daily.
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS autoblog_state (
+        id INTEGER PRIMARY KEY DEFAULT 1,
+        recent_angles TEXT[] NOT NULL DEFAULT ARRAY[]::text[],
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        CONSTRAINT single_row_autoblog_state CHECK (id = 1)
+      )
+    `);
+    await client.query('INSERT INTO autoblog_state (id) VALUES (1) ON CONFLICT (id) DO NOTHING');
+
+    const ANGLES = [
+      {
+        key: 'sme-cashflow',
+        label: 'SME cashflow and working capital without getting scammed',
+        newsQuery: 'Nigeria SME working capital funding microfinance BOI CBN intervention'
+      },
+      {
+        key: 'agri-value-chain',
+        label: 'Agribusiness value chain funding, equipment, and off-take contracts',
+        newsQuery: 'Nigeria agriculture funding grants loans equipment off-take contracts'
+      },
+      {
+        key: 'women-youth',
+        label: 'Women and youth founder opportunities plus practical application tactics',
+        newsQuery: 'Nigeria women youth entrepreneurship funding grants accelerators'
+      },
+      {
+        key: 'manufacturing',
+        label: 'Manufacturing scale-up: power costs, equipment financing, and export readiness',
+        newsQuery: 'Nigeria manufacturing funding equipment financing export incentives'
+      },
+      {
+        key: 'health-ed',
+        label: 'Healthcare and education operators: growth capital and compliance moves',
+        newsQuery: 'Nigeria healthcare education funding grants loans compliance'
+      },
+      {
+        key: 'clean-energy',
+        label: 'Clean energy and climate programs: solar, mini-grids, and impact capital',
+        newsQuery: 'Nigeria clean energy climate funding solar mini-grid impact capital'
+      },
+      {
+        key: 'creative-economy',
+        label: 'Creative economy: monetization, IP, distribution, and brand partnerships',
+        newsQuery: 'Nigeria creative economy funding film music fashion grants programs'
+      }
+    ];
+
+    const stateRes = await client.query('SELECT recent_angles FROM autoblog_state WHERE id=1');
+    const recentAngles = Array.isArray(stateRes.rows?.[0]?.recent_angles) ? stateRes.rows[0].recent_angles : [];
+    const recentSet = new Set(recentAngles.map((s) => String(s || '').trim()).filter(Boolean));
+
+    const candidates = ANGLES.filter(a => !recentSet.has(a.key));
+    const pickFrom = candidates.length > 0 ? candidates : ANGLES;
+    const angle = pickFrom[Math.floor(Math.random() * pickFrom.length)];
+
+    const nextRecent = [angle.key, ...recentAngles.filter((k) => String(k) !== String(angle.key))].slice(0, 7);
+    await client.query('UPDATE autoblog_state SET recent_angles = $1, updated_at = CURRENT_TIMESTAMP WHERE id=1', [nextRecent]);
+
+    const newsItems = await fetchNewsItems(`${angle.newsQuery} funding grants loans opportunities`);
     const newsContext = newsItems
       .map((i, idx) => `${idx + 1}. ${i.title}${i.pubDate ? ` (${i.pubDate})` : ''} - ${i.link}`)
       .join('\n');
 
     const systemInstruction = `You are a top-tier Nigerian business consultant and financial journalist.
-Write an authoritative, human-sounding 650-900 word article in HTML format.
+  Write an authoritative, human-sounding 850-1200 word article in HTML format.
 
   TITLE RULE:
   - The first <h2> is the title. Do NOT include any date in the title.
@@ -351,11 +411,22 @@ CRITICAL CONTENT RULES:
 2b. Do NOT include a "Conclusion" section or wrap-up paragraph. End with concrete next steps.
 3. FOCUS deeply on Nigeria: use Naira (₦), mention local states, or CBN/BOI policies.
 4. SOUND like a person, not a textbook. Be strategic and actionable.
-5. LINKS: Do NOT include raw URLs in the body. Do NOT add a Sources section or citations.
+5. LINKS: Do NOT include raw URLs in the body. Do NOT add a Sources section or citations. We will append Sources separately.
 6. AVOID too much use of Additionally
-7. FORMAT: Use <h2>, <h3>, <p>, <strong>, <ul>, <li>, and <a> tags only.`;
+7. FORMAT: Use <h2>, <h3>, <p>, <strong>, <ul>, <li>, and <a> tags only.
+8. PROFESSIONAL TONE: write like a newsroom + operator, not an ad.
+9. SPECIFICITY: include at least 1 short Nigeria-specific mini example (2-4 sentences) to ground the piece.`;
 
-    const userPrompt = `Write today's Nigeria Funding & Opportunities Briefing.\n\nCover a mix of sectors where funding is needed (examples: technology, healthcare, agriculture, education, manufacturing, clean energy, creative economy).\n\nInclude:\n- 3-5 practical moves readers can take today\n- A short section on avoiding scams\n- Clear next steps\n\nTopic direction: fresh opportunities (grants/loans/accelerators/market programs) and policy-related updates (if relevant).`;
+  const userPrompt = `Write a Nigeria Funding & Growth Briefing with this angle: ${angle.label}.
+
+Structure:
+- <h2> punchy title (no date)
+- 1 strong opening paragraph that sets the real problem Nigerian founders face
+- 3-5 <h3> sections with crisp subheads
+- A "Avoiding scams" section with concrete red flags
+- A "What to do this week" section with 5-7 bullet next steps
+
+Use the headlines context for timely specifics when possible, but do not invent facts.`;
 
     const messages = [
       { role: 'system', content: systemInstruction },

--- a/backend/handlers/cron_daily_blog.js
+++ b/backend/handlers/cron_daily_blog.js
@@ -383,15 +383,21 @@ export default async function handler(req, res) {
       }
     ];
 
+    // Keep the "recent" window smaller than the number of available angles,
+    // so we always have at least one non-recent candidate to choose from.
+    const RECENT_ANGLE_WINDOW = Math.max(0, Math.min(5, Math.max(0, ANGLES.length - 1)));
+
     const stateRes = await client.query('SELECT recent_angles FROM autoblog_state WHERE id=1');
-    const recentAngles = Array.isArray(stateRes.rows?.[0]?.recent_angles) ? stateRes.rows[0].recent_angles : [];
-    const recentSet = new Set(recentAngles.map((s) => String(s || '').trim()).filter(Boolean));
+    const recentAnglesRaw = Array.isArray(stateRes.rows?.[0]?.recent_angles) ? stateRes.rows[0].recent_angles : [];
+    const recentAnglesClean = recentAnglesRaw.map((s) => String(s || '').trim()).filter(Boolean);
+    const recentAngles = RECENT_ANGLE_WINDOW > 0 ? recentAnglesClean.slice(0, RECENT_ANGLE_WINDOW) : [];
+    const recentSet = new Set(recentAngles);
 
     const candidates = ANGLES.filter(a => !recentSet.has(a.key));
     const pickFrom = candidates.length > 0 ? candidates : ANGLES;
     const angle = pickFrom[Math.floor(Math.random() * pickFrom.length)];
 
-    const nextRecent = [angle.key, ...recentAngles.filter((k) => String(k) !== String(angle.key))].slice(0, 7);
+    const nextRecent = [angle.key, ...recentAngles.filter((k) => String(k) !== String(angle.key))].slice(0, RECENT_ANGLE_WINDOW);
     await client.query('UPDATE autoblog_state SET recent_angles = $1, updated_at = CURRENT_TIMESTAMP WHERE id=1', [nextRecent]);
 
     const newsItems = await fetchNewsItems(`${angle.newsQuery} funding grants loans opportunities`);

--- a/backend/handlers/uploads_status.js
+++ b/backend/handlers/uploads_status.js
@@ -6,8 +6,6 @@ import { ensureAdminFromQueryOrHeader } from './gdrive_shared.js';
 import { getGDriveRefreshToken, refreshGDriveAccessToken, toStr as gToStr } from './gdrive_shared.js';
 import { getOneDriveRefreshToken, refreshOneDriveAccessToken, toStr as oToStr } from './onedrive_shared.js';
 
-const toStr = (v) => (typeof v === 'string' ? v : Array.isArray(v) ? v.join(',') : v === undefined || v === null ? '' : String(v));
-
 export default async function handler(req, res) {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
@@ -58,10 +56,10 @@ export default async function handler(req, res) {
   }
 
   // Default: S3/R2-compatible configuration
-  const bucket = toStr(process.env.S3_BUCKET).trim();
-  const accessKeyId = toStr(process.env.S3_ACCESS_KEY_ID).trim();
-  const secretAccessKey = toStr(process.env.S3_SECRET_ACCESS_KEY).trim();
-  const publicBaseUrl = toStr(process.env.S3_PUBLIC_BASE_URL).trim();
+  const bucket = gToStr(process.env.S3_BUCKET).trim();
+  const accessKeyId = gToStr(process.env.S3_ACCESS_KEY_ID).trim();
+  const secretAccessKey = gToStr(process.env.S3_SECRET_ACCESS_KEY).trim();
+  const publicBaseUrl = gToStr(process.env.S3_PUBLIC_BASE_URL).trim();
   const configured = Boolean(bucket && accessKeyId && secretAccessKey && publicBaseUrl);
 
   return res.status(200).json({ enabled: true, provider, connected: configured, configured });

--- a/backend/handlers/uploads_status.js
+++ b/backend/handlers/uploads_status.js
@@ -1,0 +1,68 @@
+// Handler: /api/uploads/status
+// Admin-only endpoint that reports which offsite uploads provider is active
+// and whether it is configured/connected.
+
+import { ensureAdminFromQueryOrHeader } from './gdrive_shared.js';
+import { getGDriveRefreshToken, refreshGDriveAccessToken, toStr as gToStr } from './gdrive_shared.js';
+import { getOneDriveRefreshToken, refreshOneDriveAccessToken, toStr as oToStr } from './onedrive_shared.js';
+
+const toStr = (v) => (typeof v === 'string' ? v : Array.isArray(v) ? v.join(',') : v === undefined || v === null ? '' : String(v));
+
+export default async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, X-Admin-Session');
+  if (req.method === 'OPTIONS') return res.status(200).end();
+  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' });
+
+  const { ok } = await ensureAdminFromQueryOrHeader(req, { headerKey: 'x-admin-session' });
+  if (!ok) return res.status(401).json({ error: 'Unauthorized' });
+
+  const enabled = String(process.env.OFFSITE_UPLOADS_ENABLED || '').toLowerCase() === 'true';
+  const provider = String(process.env.OFFSITE_UPLOADS_PROVIDER || 's3').toLowerCase();
+
+  if (!enabled) {
+    return res.status(200).json({ enabled: false, provider, connected: false });
+  }
+
+  if (provider === 'gdrive') {
+    const refreshToken = await getGDriveRefreshToken();
+    const hasToken = Boolean(gToStr(refreshToken).trim());
+    if (!hasToken) return res.status(200).json({ enabled: true, provider, connected: false });
+
+    try {
+      await refreshGDriveAccessToken(req);
+      return res.status(200).json({ enabled: true, provider, connected: true });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Google Drive auth error';
+      const lower = String(msg || '').toLowerCase();
+      const needsReconnect = lower.includes('invalid_grant') || lower.includes('token has been expired') || lower.includes('revoked');
+      return res.status(200).json({ enabled: true, provider, connected: false, needsReconnect, error: msg });
+    }
+  }
+
+  if (provider === 'onedrive') {
+    const refreshToken = await getOneDriveRefreshToken();
+    const hasToken = Boolean(oToStr(refreshToken).trim());
+    if (!hasToken) return res.status(200).json({ enabled: true, provider, connected: false });
+
+    try {
+      await refreshOneDriveAccessToken(req);
+      return res.status(200).json({ enabled: true, provider, connected: true });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'OneDrive auth error';
+      const lower = String(msg || '').toLowerCase();
+      const needsReconnect = lower.includes('invalid_grant') || lower.includes('token has been expired') || lower.includes('revoked');
+      return res.status(200).json({ enabled: true, provider, connected: false, needsReconnect, error: msg });
+    }
+  }
+
+  // Default: S3/R2-compatible configuration
+  const bucket = toStr(process.env.S3_BUCKET).trim();
+  const accessKeyId = toStr(process.env.S3_ACCESS_KEY_ID).trim();
+  const secretAccessKey = toStr(process.env.S3_SECRET_ACCESS_KEY).trim();
+  const publicBaseUrl = toStr(process.env.S3_PUBLIC_BASE_URL).trim();
+  const configured = Boolean(bucket && accessKeyId && secretAccessKey && publicBaseUrl);
+
+  return res.status(200).json({ enabled: true, provider, connected: configured, configured });
+}

--- a/pages/Admin.tsx
+++ b/pages/Admin.tsx
@@ -341,7 +341,7 @@ export const Admin: React.FC = () => {
 
       if (connectUrl) {
         try { window.open(connectUrl, '_blank', 'noopener,noreferrer'); } catch {}
-        alert('Google Drive is not connected yet. A Google consent page was opened; complete it, then retry the upload.');
+        alert('Cloud storage is not connected yet. A consent page was opened; complete it, then retry the upload.');
         return;
       }
 
@@ -982,7 +982,7 @@ export const Admin: React.FC = () => {
 
       if (connectUrl) {
         try { window.open(connectUrl, '_blank', 'noopener,noreferrer'); } catch {}
-        alert('Google Drive is not connected yet. A Google consent page was opened; complete it, then retry the upload.');
+        alert('Cloud storage is not connected yet. A consent page was opened; complete it, then retry the upload.');
         return;
       }
 
@@ -2484,7 +2484,7 @@ export const Admin: React.FC = () => {
                            title="Claps"
                          />
 
-                         {oneDriveStatus && oneDriveStatus.enabled && oneDriveStatus.provider === 'gdrive' && (
+                         {oneDriveStatus && oneDriveStatus.enabled && (
                            <div
                              className={
                                "md:col-span-2 text-[10px] font-bold uppercase tracking-wider " +
@@ -2494,7 +2494,7 @@ export const Admin: React.FC = () => {
                              }
                              title={oneDriveStatus.error || ''}
                            >
-                             Google Drive: {oneDriveStatus.connected ? 'Connected' : (oneDriveStatus.needsReconnect ? 'Needs reconnect' : 'Not connected')}
+                             Uploads ({String(oneDriveStatus.provider || 'unknown')}): {oneDriveStatus.connected ? 'Ready' : (oneDriveStatus.needsReconnect ? 'Needs reconnect' : 'Not ready')}
                            </div>
                          )}
                          

--- a/pages/Admin.tsx
+++ b/pages/Admin.tsx
@@ -1331,6 +1331,13 @@ export const Admin: React.FC = () => {
              <Flag size={18} /> Moderation
            </button>
 
+           {/* Super Admin Only Tab */}
+           <button
+             onClick={() => setActiveTab('admins')}
+             className={`w-full text-left px-4 py-2 rounded mt-4 border-t border-gray-300 dark:border-gray-800 pt-4 flex items-center gap-2 transition ${activeTab === 'admins' ? 'bg-grantify-green text-white' : 'text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-800'}`}
+           >
+             <Shield size={16}/> {user.role === UserRole.SUPER_ADMIN ? 'Admins & Profile' : 'My Profile'}
+           </button>
         </div>
 
         {/* Content Area */}

--- a/pages/Home.tsx
+++ b/pages/Home.tsx
@@ -49,11 +49,20 @@ export const Home: React.FC = () => {
   const [referralData] = useState(ApiService.getMyReferralData());
 
   useEffect(() => {
+    let cancelled = false;
+
+    const withTimeout = async <T,>(p: Promise<T>, ms: number, label: string): Promise<T> => {
+      return await Promise.race([
+        p,
+        new Promise<T>((_, reject) => setTimeout(() => reject(new Error(`${label} timed out`)), ms))
+      ]);
+    };
+
     // 1. Fetch Ads Immediately for speed
     const loadAds = async () => {
       try {
         const fetchedAds = await ApiService.getAds();
-        setAds(fetchedAds);
+        if (!cancelled) setAds(fetchedAds);
       } catch (e) {
         console.warn("Failed to load ads early", e);
       }
@@ -62,25 +71,47 @@ export const Home: React.FC = () => {
 
     // 2. Fetch other content
     const loadData = async () => {
+      // Don't block the entire page if one endpoint is slow/cold.
+      const hardStop = setTimeout(() => {
+        if (!cancelled) setIsLoading(false);
+      }, 1800);
+
       try {
-        const [fetchedTestimonials, fetchedRecentApplicants, fetchedBlog, fetchedAppStats] = await Promise.all([
-          ApiService.getTestimonials(),
-          ApiService.getRecentApplicantsTicker(),
-          ApiService.getBlogPosts(),
-          ApiService.getApplicationStats()
+        const results = await Promise.allSettled([
+          withTimeout(ApiService.getTestimonials(), 6500, 'Testimonials'),
+          withTimeout(ApiService.getRecentApplicantsTicker(), 6500, 'Recent applicants'),
+          withTimeout(ApiService.getBlogPosts(), 6500, 'Blog posts'),
+          withTimeout(ApiService.getApplicationStats(), 6500, 'Application stats'),
         ]);
-        setAllTestimonials(fetchedTestimonials);
-        setRecentApplicants(fetchedRecentApplicants);
-        setBlogPosts(fetchedBlog); // Take all for the slider and other sections
-        setApplicationStats(fetchedAppStats);
+
+        if (cancelled) return;
+
+        const [t, a, b, s] = results;
+        if (t.status === 'fulfilled') setAllTestimonials(t.value);
+        if (a.status === 'fulfilled') setRecentApplicants(a.value);
+        if (b.status === 'fulfilled') setBlogPosts(b.value);
+        if (s.status === 'fulfilled') setApplicationStats(s.value);
+
+        const anyRejected = results.some(r => r.status === 'rejected');
+        if (anyRejected) {
+          console.warn('Some home data failed to load', results);
+          setError(prev => prev || 'Some content failed to load. Please refresh.');
+        }
       } catch (e) {
-        console.error("Failed to load home data", e);
-        setError('Failed to load data. Please check your connection.');
+        if (!cancelled) {
+          console.error("Failed to load home data", e);
+          setError(prev => prev || 'Failed to load data. Please check your connection.');
+        }
       } finally {
-        setIsLoading(false);
+        clearTimeout(hardStop);
+        if (!cancelled) setIsLoading(false);
       }
     };
     loadData();
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const handlePurposeChange = (val: string) => {

--- a/services/storage.ts
+++ b/services/storage.ts
@@ -376,11 +376,11 @@ export const ApiService = {
     return publicUrl;
   },
 
-  getDriveStatus: async (): Promise<{ enabled: boolean; provider: string; connected: boolean; needsReconnect?: boolean; error?: string }> => {
+  getDriveStatus: async (): Promise<{ enabled: boolean; provider: string; connected: boolean; needsReconnect?: boolean; error?: string; configured?: boolean }> => {
     const adminHeader = getAdminSessionHeader();
     if (!adminHeader) throw new Error('Admin session missing');
 
-    const res = await fetch(`${API_URL}/api/uploads/gdrive/status`, {
+    const res = await fetch(`${API_URL}/api/uploads/status`, {
       method: 'GET',
       headers: {
         'X-Admin-Session': adminHeader,
@@ -394,6 +394,7 @@ export const ApiService = {
       connected: Boolean(data?.connected),
       needsReconnect: Boolean(data?.needsReconnect),
       error: data?.error ? String(data.error) : undefined,
+      configured: typeof data?.configured === 'boolean' ? Boolean(data.configured) : undefined,
     };
   },
 


### PR DESCRIPTION
## Summary
- Adds provider-aware uploads status (`/api/uploads/status`) and uses it in Admin to show whether the configured provider is ready/needs reconnect.
- Improves daily autoblog cron: rotates angles/topics and prompts for more professional blog output.
- Reduces long homepage spinner risk via timeouts + `allSettled` (hard-stop on loading).
- Polishes Admin profile + blog editor UX/perf and keeps a11y label/id wiring.

## Test plan
- `npm run build`
- Admin → Uploads: verify status matches the active provider and reconnect prompt appears when needed.
- Home: verify initial render no longer blocks on slow/hung API calls.
- Run daily cron and confirm the next post angle differs from previous runs.